### PR TITLE
Added $destroy listener for cleanup.

### DIFF
--- a/angular-mdl.js
+++ b/angular-mdl.js
@@ -34,7 +34,10 @@
             (function(directiveName, classAsString) {
                 module.directive(directiveName, function() {
                     return {
-                        compile: function(element) {
+                        link: function(scope, element, attributes) {
+                            scope.$on('$destroy', function(){
+                                componentHandler.downgradeElements([element[0]]);
+                            });
                             componentHandler.upgradeElement(element[0], classAsString);
                         },
                         restrict: "C"

--- a/angular-mdl.js
+++ b/angular-mdl.js
@@ -34,11 +34,16 @@
             (function(directiveName, classAsString) {
                 module.directive(directiveName, function() {
                     return {
-                        link: function(scope, element, attributes) {
-                            scope.$on('$destroy', function(){
-                                componentHandler.downgradeElements([element[0]]);
-                            });
+                        compile: function(element) {
                             componentHandler.upgradeElement(element[0], classAsString);
+                
+                            return {
+                                pre: function(scope, element, attributes) {
+                                    scope.$on('$destroy', function(){
+                                      componentHandler.downgradeElements([element[0]]);
+                                    });
+                                }
+                            };
                         },
                         restrict: "C"
                     };


### PR DESCRIPTION
 By adding the $destroy listener the `downgradeElements` method can be used to clean up MDL elements. Switched to the `link` method in order to use `scope`.

This will reduce memory leaks.